### PR TITLE
Monitor exception

### DIFF
--- a/ZwiftActivityMonitorV2/src/ZPMonitorService.cs
+++ b/ZwiftActivityMonitorV2/src/ZPMonitorService.cs
@@ -135,7 +135,7 @@ namespace ZwiftActivityMonitorV2
                     try
                     {
                         await StartMonitorAsync();//.ConfigureAwait(false);
-                }
+                    }
                     catch
                     {
                         throw;

--- a/ZwiftActivityMonitorV2/src/ZPMonitorService.cs
+++ b/ZwiftActivityMonitorV2/src/ZPMonitorService.cs
@@ -150,8 +150,10 @@ namespace ZwiftActivityMonitorV2
                 {
                     t.Exception.Handle((ex) =>
                         {
-                            throw (ex);
+                            Logger.LogError(ex, "Failed to start ZwiftPacketMonitor.");
+                            return true;
                         });
+                    return;
                 }
                 
                 // Debug mode will operate a little differently than the regular game mode.


### PR DESCRIPTION
When using an external wi-fi adaptor, ZAM will not start afterwards without the adaptor connected as the following exception is thrown:
`System.ArgumentException: Interface Wi-Fi 2 not found
   at ZwiftPacketMonitor.Monitor.StartCaptureAsync(String networkInterface, CancellationToken cancellationToken)
   at ZwiftActivityMonitorV2.ZPMonitorService.StartMonitorAsync(CancellationToken cancellationToken) in C:\src\ZAM\ZwiftActivityMonitorV2\src\ZPMonitorService.cs:line 693
   at ZwiftActivityMonitorV2.ZPMonitorService.<StartMonitor>b__82_0() in C:\src\ZAM\ZwiftActivityMonitorV2\src\ZPMonitorService.cs:line 137`  

Having the exception just logged and not propagated to shutdown the entire program will fix this issue.