### PR TITLE
Change maximum font size to 64

### DIFF
--- a/ZwiftActivityMonitorV2/usercontrols/viewer/ColorAndFontViewerControl.Designer.cs
+++ b/ZwiftActivityMonitorV2/usercontrols/viewer/ColorAndFontViewerControl.Designer.cs
@@ -79,7 +79,7 @@ namespace ZwiftActivityMonitorV2
             this.nudFontSize.ColorScheme = Syncfusion.Windows.Forms.Office2007Theme.Managed;
             this.nudFontSize.Location = new System.Drawing.Point(17, 47);
             this.nudFontSize.Maximum = new decimal(new int[] {
-            15,
+            64,
             0,
             0,
             0});


### PR DESCRIPTION
Running ZAM on a big screen with high resolution requires a higher font size to make the text readable when the screen is far away. This proposed change increases the maximum allowed font size to 64.